### PR TITLE
Update gb2-update.c

### DIFF
--- a/can2udp/src/gb2-update.c
+++ b/can2udp/src/gb2-update.c
@@ -454,6 +454,7 @@ void fsm(unsigned char *netframe, struct update_config *device_config) {
 	    }
 	    printf("Start update ...\n");
 	    memcpy(next_frame, M_RESET, 13);
+	    memcpy(&device_id, &netframe[5], 4);
 	    memcpy(&next_frame[5], &device_id, 4);
 	    send_frame(next_frame);
 	    /* delay for boot ? */


### PR DESCRIPTION
Funktioniert in der derzeitigen Version nicht, da device_id nicht beschrieben wird. Mit dieser Änderung funktionieren zumindest die Gleisbox-Updates.