### PR TITLE
change UDP ports to standard and do no longer use can2udp for special…

### DIFF
--- a/can2udp/files/maecanserver.init
+++ b/can2udp/files/maecanserver.init
@@ -6,12 +6,10 @@ START=99
 start() {
 	# start MaeCAN if MaeCAN is installed
 	[ -e /www/MaeCAN-Server/ ] && {
-		can2udp -l 15734 -d 15733 -b 127.0.0.1
 		cd /www/MaeCAN-Server/node && nohup node --use_strict maecanserver.js 2>&1 > /dev/null &
         }
 }
 
 stop() {
-	killall can2udp
 	killall node
 }

--- a/maecan-server/node/config.json
+++ b/maecan-server/node/config.json
@@ -1,8 +1,8 @@
 {
   "protocol": 5,
   "new_registration_counter": 0,
-  "d_port": 15734,
-  "l_port": 15733,
+  "d_port": 15731,
+  "l_port": 15730,
   "master": false,
   "server_path": "/www/MaeCAN-Server/",
   "ip": "localhost"


### PR DESCRIPTION
Do not use special UDP ports for MaeCAN-Server, use standard ports instead and do not start the related can2udp service.

This has been tested successfully like described (in german) here:
https://www.stummiforum.de/t151919f7-Gleissignalerzeugung-mit-BananaPi-3.html#msg2584507
