### PR TITLE
Add devcontainer for SRSEII SDK

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,14 @@
+FROM mcr.microsoft.com/devcontainers/base:bookworm AS buildbase
+RUN apt-get update && apt-get install -y build-essential gawk flex git gettext libncurses5-dev libssl-dev zlib1g-dev unzip wget file rsync && rm -rf /var/lib/apt/lists/*
+
+FROM buildbase AS sdkdownload
+
+ADD http://lnxpps.de/can2udp/srseII/bin/openwrt-sdk-ramips-mt76x8_gcc-8.4.0_musl.Linux-x86_64.tar.xz /tmp/openwrt-sdk.tar.xz
+RUN cd / && tar -xJf /tmp/openwrt-sdk.tar.xz
+RUN cd /openwrt-sdk-ramips-mt76x8_gcc-8.4.0_musl.Linux-x86_64 && ./scripts/feeds update base packages luci routing telephony openwrtfiles openwrtmisc openwrtnetem node
+
+FROM buildbase
+
+COPY --from=sdkdownload --chown=vscode /openwrt-sdk-ramips-mt76x8_gcc-8.4.0_musl.Linux-x86_64 /sdk
+RUN echo '[ ! -z "$TERM" -a -r /etc/motd ] && cat /etc/motd' >> /etc/bash.bashrc
+COPY motd /etc/motd

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,34 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/debian
+{
+	"name": "srseii-sdk",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	// "image": "mcr.microsoft.com/devcontainers/base:bookworm",
+	"build": { "dockerfile": "Dockerfile" },
+	"postCreateCommand": "cd /sdk && sed \"/^src-git[[:space:]]\\+railroad/ c\\src-link railroad $WORKSPACE_FOLDER\" feeds.conf.default > feeds.conf && scripts/feeds update -a && make -j defconfig",
+	"features": {
+		"ghcr.io/devcontainers/features/python:1": {
+			"version": "3.10.0"
+		}
+	},
+	"containerEnv": {
+		"WORKSPACE_FOLDER": "${containerWorkspaceFolder}",
+		"SDK_DIR": "/sdk"
+		//"STAGING_DIR": "/sdk/staging_dir/",
+		//"CC" :"/sdk/staging_dir/toolchain-mipsel_24kc_gcc-8.4.0_musl/bin/mipsel-openwrt-linux-gcc",
+		//"CXX": "/sdk/staging_dir/toolchain-mipsel_24kc_gcc-8.4.0_musl/bin/mipsel-openwrt-linux-g++",
+		//"LD": "/sdk/staging_dir/toolchain-mipsel_24kc_gcc-8.4.0_musl/bin/mipsel-openwrt-linux-ld%"
+	}
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/.devcontainer/motd
+++ b/.devcontainer/motd
@@ -1,0 +1,22 @@
+#####################################################################
+
+This is the devcontainer for the OpenWRT SDK for SRSEII.
+The SDK will let you cross-compile and package code for the SRSEII.
+
+See http://lnxpps.de/can2udp/srseII/ for details about the hardware.
+See https://openwrt.org/docs/guide-developer/toolchain/using_the_sdk for information about general usage of the OpenWRT SDK.
+
+The SDK is located in the folder "/sdk".
+To build the package "can2udp", do the following:
+
+  cd /sdk
+  ./scripts/feeds install can2udp
+  make package/can2udp/compile -j
+
+You can then find the compiled package in ./bin/packages/mipsel_24kc/railroad/can2udp_2.62_mipsel_24kc.ipk
+
+If you want to manually cross-compile code for the target, set the environment variables STAGING_DIR, CC, CXX, LD (see .devcontainer/devcontainer.json for the values). Don't forget to unset them before going back to using the SDK, or you will see lots of really confusing errors.
+
+Happy Coding!
+
+#####################################################################


### PR DESCRIPTION
Adds a devcontainer containing the SDK for SRSEII. This includes the cross compiler for compiling individual binaries as well as all the infrastructure needed to produce *.ipk packages.

The SDK is set up to accomodate the local working copy of the "railroad" repository as a feed.