### PR TITLE
clarifications for read/write config and event report selection

### DIFF
--- a/can-monitor/src/can-monitor.c
+++ b/can-monitor/src/can-monitor.c
@@ -375,12 +375,18 @@ static void decode_frame(struct can_frame *frame) {
 	cv_number = ((frame->data[4] & 0x3) << 8) + frame->data[5];
 	cv_index = frame->data[4] >> 2;
 	if (frame->can_dlc == 8) {
-	    printf("Write Config %s CV Nummer %u Index %u Wert %u Ctrl 0x%02X:", getDesc(frame->data, s),
-		   cv_number, cv_index, frame->data[6], frame->data[7]);
-		if (frame->data[7] & 0x80) printf(" PRGL");
+		if (frame->data[7] & 0x10)
+			printf("Write Config %s REG Nummer %u Wert %u Ctrl 0x%02X",
+				getDesc(frame->data, s), cv_number, frame->data[6], frame->data[7]);
+		else {
+	    	printf("Write Config %s CV Nummer %u Index %u ", getDesc(frame->data, s), cv_number, cv_index);
+			if (frame->data[7] & 0x20)
+			printf("BIT %u -> %u", frame->data[6] & 7, (frame->data[6] >> 4) & 1);
+	    	else
+			printf("Wert %u Ctrl 0x%02X", frame->data[6], frame->data[7]);
+		}
+		if (frame->data[7] & 0x80) printf(" POM");
 		if (frame->data[7] & 0x40) printf(" MULTI");
-		if (frame->data[7] & 0x20) printf(" BIT");
-		if (frame->data[7] & 0x10) printf(" REG");
 	}
 	else
 	    printf("Write Config %s Befehl unbekannt\n", getDesc(frame->data, s));
@@ -390,7 +396,7 @@ static void decode_frame(struct can_frame *frame) {
 	cv_number = ((frame->data[4] & 0x3) << 8) + frame->data[5];
 	cv_index = frame->data[4] >> 2;
 	if (frame->can_dlc == 8) {
-	    printf("Write Config %s CV Nummer %u Index %u Wert %u Rslt 0x%02X:", getDesc(frame->data, s),
+	    printf("Write Config %s CV Nummer %u Index %u Wert %u Rslt 0x%02X", getDesc(frame->data, s),
 		   cv_number, cv_index, frame->data[6], frame->data[7]);
 		if (frame->data[7] & 0x80) printf(" WR_OK");
 		if (frame->data[7] & 0x40) printf(" VER_OK");

--- a/can-monitor/src/can-monitor.c
+++ b/can-monitor/src/can-monitor.c
@@ -67,13 +67,13 @@ static char *F_N_UDP_FORMAT_STRG = "  UDP  0x%08X  [%d]";
 static char *F_N_TCP_FORMAT_STRG = "  TCP  0x%08X  [%d]";
 static char *F_N_SFF_FORMAT_STRG = "  CAN  <S>  0x%03X  [%d]";
 
-void INThandler(int sig) {
+static void INThandler(int sig) {
     signal(sig, SIG_IGN);
     fputs(RESET, stdout);
     exit(0);
 }
 
-void print_usage(char *prg) {
+static void print_usage(const char *prg) {
     fprintf(stderr, "\nUsage: %s -i <can|net interface>\n", prg);
     fprintf(stderr, "   Version 5.22\n\n");
     fprintf(stderr, "         -i <can|net int>  CAN or network interface - default can0\n");
@@ -87,9 +87,9 @@ void print_usage(char *prg) {
     fprintf(stderr, "         -h                show this help\n\n");
 }
 
-struct timeval time_stamp(char *timestamp) {
+static struct timeval time_stamp(char *timestamp) {
     struct timeval tv;
-    struct tm *tm;
+    const struct tm *tm;
 
     gettimeofday(&tv, NULL);
     tm = localtime(&tv.tv_sec);
@@ -98,19 +98,19 @@ struct timeval time_stamp(char *timestamp) {
     return tv;
 }
 
-void frame_to_can(unsigned char *netframe, struct can_frame *frame) {
+static void frame_to_can(unsigned char *netframe, struct can_frame *frame) {
     frame->can_id = be32(netframe);
     frame->can_dlc = netframe[4];
     memcpy(&frame->data, &netframe[5], 8);
 }
 
-void canframe_to_can(unsigned char *netframe, struct can_frame *frame) {
+static void canframe_to_can(unsigned char *netframe, struct can_frame *frame) {
     frame->can_id = le32(netframe);
     frame->can_dlc = netframe[4];
     memcpy(&frame->data, &netframe[8], 8);
 }
 
-void ascii_to_can(char *s, struct can_frame *frame) {
+static void ascii_to_can(const char *s, struct can_frame *frame) {
     int i;
     unsigned char d[13];
 
@@ -120,7 +120,7 @@ void ascii_to_can(char *s, struct can_frame *frame) {
     frame_to_can(d, frame);
 }
 
-void slcan_to_can(char *s, struct can_frame *frame) {
+static void slcan_to_can(const char *s, struct can_frame *frame) {
     int i;
     unsigned int dat;
 
@@ -132,7 +132,7 @@ void slcan_to_can(char *s, struct can_frame *frame) {
     }
 }
 
-void candump_to_can(char *s, struct can_frame *frame) {
+static void candump_to_can(char *s, struct can_frame *frame) {
     unsigned int i, dat;
     char *candata;
 
@@ -156,7 +156,7 @@ void candump_to_can(char *s, struct can_frame *frame) {
     }
 }
 
-int print_can_frame(char *format_string, struct can_frame *frame) {
+static int print_can_frame(const char *format_string, const struct can_frame *frame) {
     int i;
     if (frame->can_dlc > 8) {
 	printf(RED " Invalid DLC %d found\n" RESET, frame->can_dlc);
@@ -189,7 +189,7 @@ int print_can_frame(char *format_string, struct can_frame *frame) {
     return 0;
 }
 
-void print_ascii_data(struct can_frame *frame) {
+static void print_ascii_data(const struct can_frame *frame) {
     int i;
 
     printf("  '");
@@ -202,7 +202,7 @@ void print_ascii_data(struct can_frame *frame) {
     printf("'\n");
 }
 
-void write_candumpfile(FILE *fp, struct timeval tv, char *name, struct can_frame *frame) {
+static void write_candumpfile(FILE *fp, struct timeval tv, const char *name, const struct can_frame *frame) {
 
     fprintf(fp, "(%ld.%06ld) %s ", tv.tv_sec, tv.tv_usec, name);
     if (frame->can_id & (CAN_EFF_FLAG | CAN_ERR_FLAG)) {
@@ -220,7 +220,7 @@ void write_candumpfile(FILE *fp, struct timeval tv, char *name, struct can_frame
     fprintf(fp, "\n");
 }
 
-void decode_frame(struct can_frame *frame) {
+static void decode_frame(struct can_frame *frame) {
     uint32_t function, uid, cv_number, cv_index;
     uint16_t kenner;
     char s[32];
@@ -609,7 +609,7 @@ void decode_frame(struct can_frame *frame) {
     }
 }
 
-void analyze_frame(struct can_frame *frame) {
+static void analyze_frame(struct can_frame *frame) {
     if (frame->can_id & CAN_EFF_FLAG) {	/* decode only EFF frames */
 	print_can_frame(F_N_CAN_FORMAT_STRG, frame);
 	if (check_cs1_frame(frame->can_id))
@@ -747,7 +747,7 @@ int main(int argc, char **argv) {
 	char can_string[MAXSIZE];
 	char datum[MAXSIZE];
 	size_t size = MAXSIZE;
-	char *pos_r, *pos_w, *pos_0;
+	const char *pos_r, *pos_w, *pos_0;
 	struct can_frame aframe;
 	int date, time, milli, slcan_format = 0;
 
@@ -814,7 +814,7 @@ int main(int argc, char **argv) {
 	const unsigned char *packet;
 	struct pcap_pkthdr header;
 	struct ip *ip_hdr;
-	struct tm *tm;
+	const struct tm *tm;
 	uint16_t sport, dport;
 	memset(timestamp, 0, sizeof(timestamp));
 

--- a/can-monitor/src/can-monitor.c
+++ b/can-monitor/src/can-monitor.c
@@ -75,7 +75,7 @@ void INThandler(int sig) {
 
 void print_usage(char *prg) {
     fprintf(stderr, "\nUsage: %s -i <can|net interface>\n", prg);
-    fprintf(stderr, "   Version 5.21\n\n");
+    fprintf(stderr, "   Version 5.22\n\n");
     fprintf(stderr, "         -i <can|net int>  CAN or network interface - default can0\n");
     fprintf(stderr, "         -r <pcap file>    read PCAP file instead from CAN socket\n");
     fprintf(stderr, "         -s                select only network internal frames\n");
@@ -304,9 +304,9 @@ void decode_frame(struct can_frame *frame) {
 	v = be16(&frame->data[4]);
 	v = v / 10;
 	if (frame->can_dlc == 4)
-	    printf("Lok %s Abfrage Fahrstufe", getLoco(frame->data, s));
+	    printf("%s Abfrage Fahrstufe", getDesc(frame->data, s));
 	else if (frame->can_dlc == 6)
-	    printf("Lok %s Geschwindigkeit: %3.1f", getLoco(frame->data, s), v);
+	    printf("%s Geschwindigkeit: %3.1f", getDesc(frame->data, s), v);
 	printf("\n");
 	break;
     /* Lok Richtung */
@@ -314,7 +314,7 @@ void decode_frame(struct can_frame *frame) {
     case 0x0B:
 	memset(s, 0, sizeof(s));
 
-	printf("Lok %s ", getLoco(frame->data, s));
+	printf("%s ", getDesc(frame->data, s));
 	if (frame->can_dlc == 4) {
 	    printf("Richtung wird abgefragt");
 	} else if (frame->can_dlc == 5) {
@@ -342,12 +342,12 @@ void decode_frame(struct can_frame *frame) {
     case 0x0C:
     case 0x0D:
 	if (frame->can_dlc == 5)
-	    printf("Lok %s Funktion %d", getLoco(frame->data, s), frame->data[4]);
+	    printf("%s Funktion %d", getDesc(frame->data, s), frame->data[4]);
 	else if (frame->can_dlc == 6)
-	    printf("Lok %s Funktion %d Wert %d", getLoco(frame->data, s), frame->data[4], frame->data[5]);
+	    printf("%s Funktion %d Wert %d", getDesc(frame->data, s), frame->data[4], frame->data[5]);
 	else if (frame->can_dlc == 7)
-	    printf("Lok %s Funktion %d Wert %d Funktionswert %d",
-		   getLoco(frame->data, s), frame->data[4], frame->data[5], be16(&frame->data[6]));
+	    printf("%s Funktion %d Wert %d Funktionswert %d",
+		   getDesc(frame->data, s), frame->data[4], frame->data[5], be16(&frame->data[6]));
 	printf("\n");
 	break;
     /* Read Config */
@@ -355,8 +355,8 @@ void decode_frame(struct can_frame *frame) {
 	if (frame->can_dlc == 7) {
 	    cv_number = ((frame->data[4] & 0x3) << 8) + frame->data[5];
 	    cv_index = frame->data[4] >> 2;
-	    printf("Read Config Lok %s CV Nummer %u Index %u Anzahl %u",
-		   getLoco(frame->data, s), cv_number, cv_index, frame->data[6]);
+	    printf("Read Config %s CV Nummer %u Index %u Anzahl %u",
+		   getDesc(frame->data, s), cv_number, cv_index, frame->data[6]);
 	}
 	printf("\n");
 	break;
@@ -364,28 +364,46 @@ void decode_frame(struct can_frame *frame) {
 	cv_number = ((frame->data[4] & 0x3) << 8) + frame->data[5];
 	cv_index = frame->data[4] >> 2;
 	if (frame->can_dlc == 6)
-	    printf("Read Config Lok %s CV Nummer %u Index %u", getLoco(frame->data, s), cv_number, cv_index);
+	    printf("Read Config %s CV Nummer %u Index %u fehlerhaft", getDesc(frame->data, s), cv_number, cv_index);
 	if (frame->can_dlc == 7)
-	    printf("Read Config Lok %s CV Nummer %u Index %u Wert %u",
-		   getLoco(frame->data, s), cv_number, cv_index, frame->data[6]);
+	    printf("Read Config %s CV Nummer %u Index %u Wert %u",
+		   getDesc(frame->data, s), cv_number, cv_index, frame->data[6]);
 	printf("\n");
 	break;
     /* Write Config */
     case 0x10:
-    case 0x11:
-	/* TODO */
 	cv_number = ((frame->data[4] & 0x3) << 8) + frame->data[5];
 	cv_index = frame->data[4] >> 2;
-	if (frame->can_dlc == 8)
-	    printf("Write Config Lok %s CV Nummer %u Index %u Wert %u Ctrl 0x%02X\n", getLoco(frame->data, s),
+	if (frame->can_dlc == 8) {
+	    printf("Write Config %s CV Nummer %u Index %u Wert %u Ctrl 0x%02X:", getDesc(frame->data, s),
 		   cv_number, cv_index, frame->data[6], frame->data[7]);
+		if (frame->data[7] & 0x80) printf(" PRGL");
+		if (frame->data[7] & 0x40) printf(" MULTI");
+		if (frame->data[7] & 0x20) printf(" BIT");
+		if (frame->data[7] & 0x10) printf(" REG");
+	}
 	else
-	    printf("Write Config Lok %s Befehl unbekannt\n", getLoco(frame->data, s));
+	    printf("Write Config %s Befehl unbekannt\n", getDesc(frame->data, s));
+	printf("\n");
+	break;
+    case 0x11:
+	cv_number = ((frame->data[4] & 0x3) << 8) + frame->data[5];
+	cv_index = frame->data[4] >> 2;
+	if (frame->can_dlc == 8) {
+	    printf("Write Config %s CV Nummer %u Index %u Wert %u Rslt 0x%02X:", getDesc(frame->data, s),
+		   cv_number, cv_index, frame->data[6], frame->data[7]);
+		if (frame->data[7] & 0x80) printf(" WR_OK");
+		if (frame->data[7] & 0x40) printf(" VER_OK");
+	}
+	else
+	    printf("Write Config %s Befehl unbekannt\n", getDesc(frame->data, s));
+	printf("\n");
 	break;
     /* Zubehör schalten */
     case 0x16:
     case 0x17:
 	uid = be32(frame->data);
+	// TODO: add an additional 2048 address block for Extended Accessory Decoders
 	if (frame->can_dlc >= 6) {
 	    if ((uid > 0x2FFF) && (uid < 0x3400))
 		printf("Magnetartikel MM1 ID %u Ausgang %u Strom %u", uid - 0x2FFF, frame->data[4], frame->data[5]);
@@ -543,8 +561,8 @@ void decode_frame(struct can_frame *frame) {
 	    kenner = be16(&frame->data[4]);
 	    printf("Connect6021 UID 0x%08X mit Kenner 0x%04X\n", uid, kenner);
 	} else if (frame->can_dlc == 5) {
-	    printf("Connect6021 Config: Lok %s gesteuert via Adresse %02u\n",
-			getLoco(frame->data, s), frame->data[4]);
+	    printf("Connect6021 Config: %s gesteuert via Adresse %02u\n",
+			getDesc(frame->data, s), frame->data[4]);
 	} else {
 	    cdb_extension_wc(frame);
 	}
@@ -558,8 +576,8 @@ void decode_frame(struct can_frame *frame) {
 	    printf("Automatik schalten: ID 0x%04X Funktion 0x%04X Stellung 0x%02X Parameter 0x%02X\n",
 		   kenner, function, frame->data[4], frame->data[5]);
 	if (frame->can_dlc == 8)
-	    printf("Automatik schalten: ID 0x%04X Funktion 0x%04X Lok %s\n", kenner, function,
-		   getLoco(&frame->data[4], s));
+	    printf("Automatik schalten: ID 0x%04X Funktion 0x%04X %s\n", kenner, function,
+		   getDesc(&frame->data[4], s));
 	break;
     /* Blocktext zuordnen */
     case 0x62:
@@ -569,7 +587,7 @@ void decode_frame(struct can_frame *frame) {
 	if (frame->can_dlc == 4)
 	    printf("Blocktext zuordnen: ID 0x%04X Funktion 0x%04X\n", kenner, function);
 	if (frame->can_dlc == 8)
-	    printf("Blocktext zuordnen: ID 0x%04X Funktion 0x%04X Lok %s\n", kenner, function, getLoco(&frame->data[4], s));
+	    printf("Blocktext zuordnen: ID 0x%04X Funktion 0x%04X %s\n", kenner, function, getDesc(&frame->data[4], s));
 	break;
     case 0x64:
     case 0x65:

--- a/can-monitor/src/decoder-can-cs2.c
+++ b/can-monitor/src/decoder-can-cs2.c
@@ -97,25 +97,44 @@ char *berechne_messwert(struct messwert_t *c_messwert, uint16_t wert) {
     return s;
 }
 
-char *getLoco(uint8_t * data, char *s) {
+char *getDesc(uint8_t * data, char *s) {
     uint16_t locID = be16(&data[2]);
     char prot[32];
     int addrs;
 
+    if (data[0] || data[1]) {
+	    sprintf(s, "UID 0x%02X%02X%04X", data[0], data[1], locID);
+	    return s;
+    }
     memset(prot, 0, sizeof(prot));
 
-    if (locID <= 0x03ff) {
-	strncpy(prot, " mm-", sizeof(prot));
-	addrs = locID;
-    } else if (locID >= 0x4000 && locID < 0xC000) {
-	strncpy(prot, "mfx-", sizeof(prot));
+    if (locID >= 0x4000 && locID < 0x8000) {
+	strncpy(prot, "Lok mfx-", sizeof(prot));
 	addrs = locID - 0x4000;
+    } else if (locID >= 0x8000 && locID < 0xC000) {
+	strncpy(prot, "Lok SX2-", sizeof(prot));
+	addrs = locID - 0x8000;
     } else if (locID >= 0xC000) {
-	strncpy(prot, "dcc-", sizeof(prot));
+	strncpy(prot, "Lok dcc-", sizeof(prot));
 	addrs = locID - 0xC000;
-    } else {
+    } else switch (data[2] & 0xFC) {
+    case 0x00:		// MM1,2 Loks und Funktionsdecoder (20 & 40 kHz, 80 & 255 Adressen)
+	strncpy(prot, "Lok mm-", sizeof(prot));
+	addrs = locID;
+	break;
+    case 0x30:		// MM1,2 Zubehörartikeldecoder (40 kHz, 320 & 1024 Adressen)
+	strncpy(prot, "Zubehör mm-", sizeof(prot));
+	addrs = locID - 0x3000;
+	break;
+	// TODO: add an additional 2048 address block for Extended Accessory Decoders
+    case 0x38:
+    case 0x3C:		// DCC-Zubehörartikel (2048 Adressen)
+	strncpy(prot, "Zubehör dcc-", sizeof(prot));
+	addrs = locID - 0x3800;
+	break;
+    default:
 	strncpy(prot, "unbekannt-", sizeof(prot));
-	addrs = 0;
+	addrs = locID;
     }
 
     sprintf(s, "%s%d", prot, addrs);
@@ -273,7 +292,6 @@ void decode_cs2_can_channels(struct can_frame *frame) {
     uint16_t paket;
     uint8_t n_kanaele;
 
-    paket = 0;
     uid = be32(frame->data);
     if (frame->can_dlc == 5) {
 	kanal = frame->data[4];
@@ -389,6 +407,39 @@ void decode_cs2_config_data(struct can_frame *frame, int expconf) {
     }
 }
 
+static void decode_event(uint8_t type)
+{
+	    switch(type) {
+	    case 0x00:
+		printf("Pin ignorieren");
+		break;
+	    case 0x01:
+		printf("Pin lesen");
+		break;
+	    case 0x02:
+		printf("Pinänderung melden");
+		break;
+	    case 0x03:
+		printf("Pin 0->1 melden");
+		break;
+	    case 0x04:
+		printf("Pin 1->0 melden");
+		break;
+	    case 0x05:
+		printf("Pin 0->1 zählen");
+		break;
+	    case 0x06:
+		printf("Pin-Zeitmessung");
+		break;
+	    case 0xFE:
+		printf("Pinstatus rücksetzen");
+		break;
+	    default:
+		printf("Parameter %d", type);
+		break;
+	    }
+}
+
 void decode_cs2_s88(struct can_frame *frame) {
     uint16_t kenner, kontakt;
 
@@ -397,28 +448,19 @@ void decode_cs2_s88(struct can_frame *frame) {
 
     if (frame->can_id & 0x00010000) {
 	if (frame->can_dlc == 8)
-	    printf("S88 Event Kennung %d Kontakt %d Zustand alt %d Zustand neu %d Zeit %d",
+	    printf("S88 Event Kennung %d Kontakt %d Zustand alt %d, neu %d Zeit %d",
 		    kenner, kontakt, frame->data[4], frame->data[5], be16(&frame->data[6]));
 	printf("\n");
     } else {
 	if (frame->can_dlc == 4)
-	    printf("S88 Event Kennung %d Kontakt %d", kenner, kontakt);
-	else if (frame->can_dlc == 5)
-	    printf("S88 Event Kennung %d Kontakt %d Parameter %d", kenner, kontakt, frame->data[4]);
+	    printf("S88 Event Kennung %d Kontakt %d abfragen", kenner, kontakt);
+	else if (frame->can_dlc == 5) {
+	    printf("S88 Event Kennung %d Kontakt %d ", kenner, kontakt);
+	    decode_event(frame->data[4]);
+	}
 	else if (frame->can_dlc == 7) {
-	    printf("S88 Event Blockmodus Kennung %d Kontakt Start %d Kontakt Ende %d ", kenner, kontakt, be16(&frame->data[4]));
-	    /* TODO: Parameter */
-	    switch(frame->data[6]) {
-	    case 0x00:
-		printf("Pin zurück setzen");
-		break;
-	    case 0x01:
-		printf("Pin lesen");
-		break;
-	    default:
-		printf("Parameter %d", frame->data[6]);
-		break;
-	    }
+	    printf("S88 Event Blockmodus Kennung %d Kontakte %d bis %d ", kenner, kontakt, be16(&frame->data[4]));
+	    decode_event(frame->data[6]);
 	}
 	printf("\n");
     }
@@ -478,15 +520,15 @@ void decode_cs2_system(struct can_frame *frame) {
     case 0x03:
 	printf("System: ");
 	if (uid)
-	    printf("Lok %s Nothalt", getLoco(frame->data, s));
+	    printf("%s Nothalt", getDesc(frame->data, s));
 	else
 	    writeRed("Nothalt alle Loks");
 	break;
     case 0x04:
-	printf("System: Lok %s Zyklus Ende", getLoco(frame->data, s));
+	printf("System: %s Zyklus Ende", getDesc(frame->data, s));
 	break;
     case 0x05:
-	printf("System: Lok %s Gleisprotokoll: %d", getLoco(frame->data, s), frame->data[5]);
+	printf("System: %s Gleisunterprotokoll: %d", getDesc(frame->data, s), frame->data[5]);
 	break;
     case 0x06:
 	wert = be16(&frame->data[5]);
@@ -532,10 +574,10 @@ void decode_cs2_system(struct can_frame *frame) {
 		printf("System: Statusabfrage UID 0x%08X Kanal %d Messwert", uid, frame->data[5]);
 		struct messwert_t *c_messwert = suche_messwert(messwert_knoten, uid, frame->data[5]);
 		if (c_messwert) {
-		    char *s = berechne_messwert(c_messwert, wert);
-		    if (s) {
-			printf(" %s", s);
-			free(s);
+		    char *m = berechne_messwert(c_messwert, wert);
+		    if (m) {
+			printf(" %s", m);
+			free(m);
 		    }
 		} else {
 		    printf(" 0x%04X", wert);

--- a/can-monitor/src/decoder-can-cs2.c
+++ b/can-monitor/src/decoder-can-cs2.c
@@ -34,13 +34,13 @@ struct messwert_t *a_messwert = NULL;
 struct knoten *messwert_knoten = NULL;
 unsigned char channel_buffer[MAX_PAKETE * 8];
 
-char *next_string(char *p) {
+static char *next_string(char *p) {
     /* TODO: range check */
     while (*p++) ;
     return p++;
 }
 
-int insert_right(struct knoten *liste, void *element) {
+static int insert_right(struct knoten *liste, void *element) {
     struct knoten *tmp = liste;
     struct knoten *node = calloc(1, sizeof(struct knoten));
     if (node == NULL) {
@@ -65,7 +65,7 @@ void print_llist(struct knoten *liste) {
     }
 }
 
-struct messwert_t *suche_messwert(struct knoten *liste, uint32_t uid, uint8_t index) {
+static struct messwert_t *suche_messwert(struct knoten *liste, uint32_t uid, uint8_t index) {
     struct knoten *tmp = liste;
     struct messwert_t *messwert_tmp;
 
@@ -86,7 +86,7 @@ struct messwert_t *suche_messwert(struct knoten *liste, uint32_t uid, uint8_t in
     return NULL;
 }
 
-char *berechne_messwert(struct messwert_t *c_messwert, uint16_t wert) {
+static char *berechne_messwert(struct messwert_t *c_messwert, uint16_t wert) {
     float value;
     char *s = NULL;
 
@@ -238,7 +238,7 @@ void print_measure_data(struct messwert_t *messwert) {
 }
 #endif
 
-void decode_cs2_channel_data(unsigned char *buffer, uint32_t uid, int kanal, int messwerte) {
+static void decode_cs2_channel_data(unsigned char *buffer, uint32_t uid, int kanal, int messwerte) {
     char *p;
 
     /* TODO: still not all values are kept */

--- a/can-monitor/src/decoder-can-cs2.h
+++ b/can-monitor/src/decoder-can-cs2.h
@@ -13,7 +13,7 @@
 
 #include "can-monitor.h"
 
-char *getLoco(uint8_t * data, char *s);
+char *getDesc(uint8_t * data, char *s);
 void decode_cs2_can_channels(struct can_frame *frame);
 void decode_cs2_can_identifier(struct can_frame *frame);
 void decode_cs2_config_data(struct can_frame *frame, int expconf);

--- a/can-monitor/src/decoder-z21.c
+++ b/can-monitor/src/decoder-z21.c
@@ -6,9 +6,9 @@
 #include "can-monitor.h"
 #include "tools.h"
 
-#define ADDR(x) (be16(&data[x]) & 0x3FFF)
+#define ADDR(x) ((unsigned) be16(&data[x]) & 0x3FFF)
 
-void z21_conf_info(unsigned char *data, int datsize) {
+void z21_conf_info(const unsigned char *data, int datsize) {
     int show = datsize;
     if (show > 16)
 	show = 16;
@@ -29,7 +29,7 @@ void z21_conf_info(unsigned char *data, int datsize) {
     printf("'\n");
 }
 
-void z21_comm_ext(char *timestamp, int source, unsigned char *data, int datsize) {
+void z21_comm_ext(const char *timestamp, int source, unsigned char *data, int datsize) {
     while (datsize >= 4) {
 	int datlen = le16(&data[0]);
 	int header = le16(&data[2]);

--- a/can-monitor/src/lib.c
+++ b/can-monitor/src/lib.c
@@ -46,7 +46,6 @@
 #include <string.h>
 #include <stdint.h>
 
-#include <sys/socket.h> /* for sa_family_t */
 #include <linux/can.h>
 #include <linux/can/error.h>
 
@@ -125,7 +124,7 @@ unsigned char asc2nibble(char c) {
 
 int hexstring2data(char *arg, unsigned char *data, int maxdlen) {
 
-	int len = strlen(arg);
+	int len = (int) strlen(arg);
 	int i;
 	unsigned char tmp;
 
@@ -160,7 +159,7 @@ int parse_canframe(char *cs, struct canfd_frame *cf) {
 	int ret = CAN_MTU;
 	unsigned char tmp;
 
-	len = strlen(cs);
+	len = (int) strlen(cs);
 	//printf("'%s' len %d\n", cs, len);
 
 	memset(cf, 0, sizeof(*cf)); /* init CAN FD frame, e.g. LEN = 0 */
@@ -500,7 +499,7 @@ static const char *protocol_violation_locations[] = {
 #define ARRAY_SIZE(arr) (sizeof(arr) / sizeof((arr)[0]))
 #endif
 
-static int snprintf_error_data(char *buf, size_t len, uint8_t err,
+static int snprintf_error_data(char *buf, int len, uint8_t err,
 			       const char **arr, int arr_len)
 {
 	int i, n = 0, count = 0;
@@ -520,14 +519,14 @@ static int snprintf_error_data(char *buf, size_t len, uint8_t err,
 	return n;
 }
 
-static int snprintf_error_lostarb(char *buf, size_t len, const struct canfd_frame *cf)
+static int snprintf_error_lostarb(char *buf, int len, const struct canfd_frame *cf)
 {
 	if (len <= 0)
 		return 0;
 	return snprintf(buf, len, "{at bit %d}", cf->data[0]);
 }
 
-static int snprintf_error_ctrl(char *buf, size_t len, const struct canfd_frame *cf)
+static int snprintf_error_ctrl(char *buf, int len, const struct canfd_frame *cf)
 {
 	int n = 0;
 
@@ -543,7 +542,7 @@ static int snprintf_error_ctrl(char *buf, size_t len, const struct canfd_frame *
 	return n;
 }
 
-static int snprintf_error_prot(char *buf, size_t len, const struct canfd_frame *cf)
+static int snprintf_error_prot(char *buf, int len, const struct canfd_frame *cf)
 {
 	int n = 0;
 

--- a/can-monitor/src/tools.c
+++ b/can-monitor/src/tools.c
@@ -15,19 +15,19 @@
 #include "zlib.h"
 #include "can-monitor.h"
 
-uint16_t be16(uint8_t *u) {
+uint16_t be16(const uint8_t *u) {
     return (u[0] << 8) | u[1];
 }
 
-uint16_t le16(uint8_t *u) {
+uint16_t le16(const uint8_t *u) {
     return u[0] | (u[1] << 8);
 }
 
-uint32_t be32(uint8_t *u) {
+uint32_t be32(const uint8_t *u) {
     return (u[0] << 24) | (u[1] << 16) | (u[2] << 8) | u[3];
 }
 
-uint32_t le32(uint8_t *u) {
+uint32_t le32(const uint8_t *u) {
     return (u[3] << 24) | (u[2] << 16) | (u[1] << 8) | u[0];
 }
 


### PR DESCRIPTION
- lower 16k block of local IDs contains not only locos, but accessory decoders too
- read config and write config commands are not restricted to locos
- control and result field of write config commands are decoded now
- event reporting setup also decoded for single selection command

one issue remains still open:
the local IDs 0x3800 to 0x3FFF cover DCC basic accessory decoders; which IDs will be used to handle  DCC extended accessory decoders?